### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @jdhoffa will be requested for review when someone opens 
+# a pull request.
+*       @jdhoffa


### PR DESCRIPTION
After a recent discussion with Matthias, we have assigned maintainers to the top 100 most recently contributed repositories under `RMI-PACTA`. 

Noting that we have yet to entirely define what a maintainer's responsibilities are, one way we can track who maintains a repository is by the `.github/CODEOWNERS` file. This file dictates who is automatically requested for review when a PR is submitted in the repo. 

Note: Several people can be requested here (thus it supports, in a sense, the idea of multiple owners). 
Note: Maintainers can be defined per file or filetype, as specified through a regrex. 

See here for more info: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

FYI. @AlexAxthelm @cjyetman @jacobvjk @MonikaFu @Antoine-Lalechere