### PR TITLE
Add `lifecycle experimental` badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # workflow.scenario.preparation
 
+<!-- badges: start -->
+
+[![Lifecycle:
+experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental) 
+<!-- badges: end -->
+
 The goal of `workflow.scenario.preparation` is to prepare all input scenario datasets required as input by both the [pactaverse](https://rmi-pacta.github.io/pactaverse/) R packages (for investors), and [r2dii](https://rmi-pacta.github.io/r2dii.analysis/) R packages (for banks).
 
 ## Setting up the `.env` file


### PR DESCRIPTION
Noting that this workflow is "in production", however, the `lifecycle` distinction is between `experimental` vs. `maturing` and `stable` (not `production`)... and of those, this feels `experimental` lol. 

Anyway, happy to use this PR as a kick-starter of a discussion