### PR TITLE
force Docker to use amd64 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # https://hub.docker.com/r/rocker/r-ver
 # https://rocker-project.org/images/versioned/r-ver.html
 ARG R_VERS="4.3.1"
-FROM --platform="${BUILDPLATFORM:-linux/amd64}" rocker/r-ver:$R_VERS AS base
+FROM --platform="${TARGETPLATFORM:-linux/amd64}" rocker/r-ver:$R_VERS AS base
 
 # set Docker image labels
 LABEL org.opencontainers.image.source=https://github.com/RMI-PACTA/workflow.scenario.preparation

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # https://hub.docker.com/r/rocker/r-ver
 # https://rocker-project.org/images/versioned/r-ver.html
 ARG R_VERS="4.3.1"
-FROM --platform="linux/amd64" rocker/r-ver:$R_VERS AS base
+FROM --platform="${BUILDPLATFORM:-linux/amd64}" rocker/r-ver:$R_VERS AS base
 
 # set Docker image labels
 LABEL org.opencontainers.image.source=https://github.com/RMI-PACTA/workflow.scenario.preparation

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 # using rocker r-vers as a base with R 4.3.1
 # https://hub.docker.com/r/rocker/r-ver
 # https://rocker-project.org/images/versioned/r-ver.html
-ARG PLATFORM="linux/amd64"
 ARG R_VERS="4.3.1"
-FROM --platform=$PLATFORM rocker/r-ver:$R_VERS AS base
+FROM --platform="linux/amd64" rocker/r-ver:$R_VERS AS base
 
 # set Docker image labels
 LABEL org.opencontainers.image.source=https://github.com/RMI-PACTA/workflow.scenario.preparation

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 # using rocker r-vers as a base with R 4.3.1
 # https://hub.docker.com/r/rocker/r-ver
 # https://rocker-project.org/images/versioned/r-ver.html
+ARG PLATFORM="linux/amd64"
 ARG R_VERS="4.3.1"
-FROM rocker/r-ver:$R_VERS AS base
+FROM --platform=$PLATFORM rocker/r-ver:$R_VERS AS base
 
 # set Docker image labels
 LABEL org.opencontainers.image.source=https://github.com/RMI-PACTA/workflow.scenario.preparation

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 # https://hub.docker.com/r/rocker/r-ver
 # https://rocker-project.org/images/versioned/r-ver.html
 ARG R_VERS="4.3.1"
+ARG TARGETPLATFORM="linux/amd64"
 FROM --platform="${TARGETPLATFORM:-linux/amd64}" rocker/r-ver:$R_VERS AS base
 
 # set Docker image labels

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@
 # https://hub.docker.com/r/rocker/r-ver
 # https://rocker-project.org/images/versioned/r-ver.html
 ARG R_VERS="4.3.1"
-ARG TARGETPLATFORM="linux/amd64"
-FROM --platform="${TARGETPLATFORM:-linux/amd64}" rocker/r-ver:$R_VERS AS base
+FROM rocker/r-ver:$R_VERS AS base
 
 # set Docker image labels
 LABEL org.opencontainers.image.source=https://github.com/RMI-PACTA/workflow.scenario.preparation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
-version: "3.2"
+version: "3.8"
 
 services:
   scenario_prep:
+    platform: linux/amd64
     build:
       context: .
     environment:


### PR DESCRIPTION
Otherwise by default on macOS it tries to build with an arm64 image, and then the package installs fail because Posit Package Manager doesn't supply proper linux/arm64 binaries.

ℹ️ hadolint doesn't seem to like this unless it's `FROM --platform="${TARGETPLATFORM:-linux/amd64}"` see https://github.com/hadolint/hadolint/issues/861