### PR TITLE
Delete .Rprofile

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,1 +1,0 @@
-if (file.exists(".env")) readRenviron(".env")


### PR DESCRIPTION
RStudio seems to set whatever environment variables are set in R in its integrated Terminal, which ends up meaning that whatever `R_CONFIG_ACTIVE` was set when RStudio was first opened will always be present in a new Terminal it creates, which prevents docker-compose from picking up any change made to `.env`.

Only loss is that when running in RStudio I have to be more cautious about manually running `Sys.setenv(R_CONFIG_ACTIVE = "YYYYQQ")` every time.