### PR TITLE
ignore non-standard files in `.Rbuildignore`

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,11 @@
 ^LICENSE\.md$
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^Dockerfile$
+^config\.yml$
+^docker-compose\.yml$
+^example\.env$
+^\.github$
+^\.env$
+^outputs$
+^.*\.R$


### PR DESCRIPTION
so R CMD check can be run without warnings about them (R CMD check can be useful even though this is not an R pkg, e.g. to check for a valid DESCRIPTION file and hypothetically run R tests in the future)