### PR TITLE
fix(app): #43 Change csv reading function

### DIFF
--- a/process_scenario_weo_2022.R
+++ b/process_scenario_weo_2022.R
@@ -107,9 +107,11 @@ weo_2022_sales_aps_auto_raw <-
   )
 
 weo_2022_electric_sales_aps_auto_raw <-
-  readr::read_csv(
+  read.table(
     file = weo_2022_electric_sales_aps_auto_raw_full_filename,
-    show_col_types = FALSE
+    header = TRUE,
+    sep = ",",
+    fill = TRUE
   )
 
 logger::log_info("WEO 2022: Processing WEO 2022 data.")


### PR DESCRIPTION
Changes from using `readr::read_csv()` to `read.table()` with `fill=TRUE` to handle non-rectangular CSV (one extra column on line 2)

Closes: #43