### PR TITLE
use `stop()` whenever an error is logged with `logger::log_error()`

### DIFF
--- a/main.R
+++ b/main.R
@@ -12,6 +12,7 @@ if (fs::dir_exists(scenario_preparation_inputs_path)) {
   logger::log_info("Setting scenario preparation inputs path: {scenario_preparation_inputs_path}")
 } else {
   logger::log_error("Scenario preparation inputs path does not exist: {scenario_preparation_inputs_path}")
+  stop()
 }
 
 
@@ -24,6 +25,7 @@ if (fs::dir_exists(scenario_preparation_outputs_path)) {
   logger::log_info("Setting scenario preparation outputs path: {scenario_preparation_outputs_path}")
 } else {
   logger::log_error("Scenario preparation outputs path does not exist: {scenario_preparation_outputs_path}")
+  stop()
 }
 
 

--- a/process_scenario_geco_2022.R
+++ b/process_scenario_geco_2022.R
@@ -275,4 +275,5 @@ if (pacta.data.validation::validate_intermediate_scenario_output(geco_2022)) {
 
 } else {
   logger::log_error("GECO 2022: GECO 2022 data is not valid.")
+  stop()
 }

--- a/process_scenario_geco_2023.R
+++ b/process_scenario_geco_2023.R
@@ -206,14 +206,15 @@ if (pacta.data.validation::validate_intermediate_scenario_output(geco_2023)) {
   logger::log_info("GECO 2023: GECO 2023 data is valid.")
 
   output_path <- fs::path(scenario_preparation_outputs_path, "geco_2023.csv")
-  
+
   readr::write_csv(
     x = geco_2023,
     file = output_path
   )
 
   logger::log_info("GECO 2023: GECO 2023 data saved to {output_path}.")
-  
+
 } else {
   logger::log_error("GECO 2023 data is not valid.")
+  stop()
 }

--- a/process_scenario_isf_2021.R
+++ b/process_scenario_isf_2021.R
@@ -63,4 +63,5 @@ if (pacta.data.validation::validate_intermediate_scenario_output(isf_2021)) {
 
 } else {
   logger::log_error("ISF 2021 data is not valid.")
+  stop()
 }

--- a/process_scenario_isf_2023.R
+++ b/process_scenario_isf_2023.R
@@ -85,4 +85,5 @@ if (pacta.data.validation::validate_intermediate_scenario_output(isf_2023)) {
 
 } else {
   logger::log_error("ISF 2023 data is not valid.")
+  stop()
 }

--- a/process_scenario_weo_2022.R
+++ b/process_scenario_weo_2022.R
@@ -139,4 +139,5 @@ if (pacta.data.validation::validate_intermediate_scenario_output(weo_2022)) {
 
 } else {
   logger::log_error("WEO 2022 data is not valid.")
+  stop()
 }

--- a/process_scenario_weo_2023.R
+++ b/process_scenario_weo_2023.R
@@ -122,4 +122,5 @@ if (pacta.data.validation::validate_intermediate_scenario_output(weo_2023)) {
 
 } else {
   logger::log_error("WEO 2023 data is not valid.")
+  stop()
 }


### PR DESCRIPTION
- closes #32 