### PR TITLE
ci/cd: remove daily workflow trigger

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,8 +10,6 @@ on:
   pull_request:
   push:
     branches: [main]
-  schedule:
-    - cron: '0 0 * * 1,2,3,4,5'
   workflow_dispatch:
 
 name: docker


### PR DESCRIPTION
FYI @AlexAxthelm I think it's unnecessary to trigger new scenario builds every day. 

It ends up just making it very difficult to validate if we are choosing the correct version of scenario outputs to include in a PROD run of data prep. 

Suggest leaving it to only merges to `main` and `workflow_dispatch` triggers.

As an example, `2023Q4_20240416_T140550Z` was the last scenario build with any meaningful change of information in it, but on Azure we have:
<img width="253" alt="Screenshot 2024-05-15 at 07 22 30" src="https://github.com/RMI-PACTA/workflow.scenario.preparation/assets/8741309/3ad38296-04d2-4e6d-b724-ba7b12506c0a">
